### PR TITLE
default time out, in memory , pattern

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -2,10 +2,14 @@ import { defineConfig } from 'cypress'
 
 export default defineConfig({
   projectId: 'v2x96h',
+  numTestsKeptInMemory: 0,
+  defaultCommandTimeout: 60000,
   e2e: {
     setupNodeEvents(on, config) {
     },
     baseUrl: 'http://localhost:3003',
-    experimentalSessionAndOrigin: true
+    experimentalSessionAndOrigin: true,
+    specPattern: 'cypress/e2e/**/*.{js,jsx,ts,tsx}',
+    numTestsKeptInMemory: 0,
   },
 })


### PR DESCRIPTION
1. the default time out in the cypress config file because of some time out error for internet speed 
2. numTestsKeptInMemory: test run to create cash garbage add this command to handle the memory side
3. pattern space: specific file create like js,jsx,ts,tsx