### PR TITLE
poc: add a toolbar into test runner

### DIFF
--- a/src/components/Toolbar.vue
+++ b/src/components/Toolbar.vue
@@ -1,0 +1,20 @@
+<template>
+  <button @click="copyLink">Hey there</button>
+</template>
+<script setup lang="ts">
+
+const allProps = defineProps({
+  props: {
+    default: [],
+    type: Object
+  }
+});
+
+const copyLink = async () => {
+  const { props }: any = allProps
+  const type = typeof props
+  const clipBoardValue = type === 'object' ? JSON.stringify(props, null, 2) : props
+  await parent.navigator.clipboard.writeText(clipBoardValue);
+}
+
+</script>

--- a/src/style.css
+++ b/src/style.css
@@ -4,7 +4,7 @@
 
 #api-view {
   @apply fixed top-0 left-0 right-0 bottom-0 bg-white h-screen overflow-scroll mb-10 ;
-  z-index: 9999999
+  z-index: 100
 }
 
 pre {

--- a/src/toolbarStyles.css
+++ b/src/toolbarStyles.css
@@ -1,0 +1,12 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+#api-toolbar {
+  @apply relative top-0 left-0 bg-gray-50 p-4 w-full;
+  z-index: 101
+}
+
+#api-toolbar > button {
+  @apply bg-cy-blue text-white px-2 py-1 rounded
+}


### PR DESCRIPTION
Some comments on this:
- the toolbar is now basically a separate vue app that uses the same props as the plugin
- so far it can only render and copy contents of all props into clipboard
- it works in snapshots
- it does not make too much sense. yeah, there is a copy button and potentially it could copy anything we want, but having it at the top of the toolbar does not really make sense. I could see this having a potential for some global actions, like saving list of APIs into a file or something but not sure