### PR TITLE
ci: enable npm trusted publishing (OIDC)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,13 +3,18 @@ on: [push]
 jobs:
   cypress-run:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write       # semantic-release pushes tags / GitHub release
+      id-token: write       # required for npm trusted publishing (OIDC)
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: '22.14.0'
-      - name: Checkout
-        uses: actions/checkout@v2
+      - name: Upgrade npm for trusted publishing
+        run: npm install -g npm@latest   # needs >= 11.5.1
       - name: Cypress run
         uses: cypress-io/github-action@v5
         with:
@@ -26,4 +31,4 @@ jobs:
           semantic_version: ^25.0.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          # NPM_TOKEN removed — OIDC trusted publishing handles auth


### PR DESCRIPTION
## What

Configures `.github/workflows/tests.yml` to publish to npm via [trusted publishing](https://docs.npmjs.com/trusted-publishers/) (OIDC) instead of a long-lived `NPM_TOKEN`.

## Changes

- **Add `id-token: write` permission** — required so GitHub mints the OIDC token npm exchanges for short-lived credentials. Also added `contents: write` for semantic-release's tags/GitHub release.
- **Upgrade npm to `npm@latest`** — trusted publishing requires npm ≥ 11.5.1; Node 22.14.0 ships 11.2.0.
- **Remove `NPM_TOKEN`** — with a token present npm prefers it and skips OIDC. `GITHUB_TOKEN` is kept for the GitHub release/changelog.
- **Bump `actions/checkout` to v4** and run it before `setup-node`.

`@semantic-release/npm@^13.1.1` and `semantic-release@^25.0.2` already support OIDC, so no dependency changes are needed.

## Follow-ups (outside this PR)

- After the first successful OIDC release, delete the `NPM_TOKEN` repo secret.
- Confirm the npm trusted publisher points at repo `filiphric/cypress-plugin-api` and workflow file `tests.yml` — a mismatch causes the OIDC exchange to be rejected.

Side benefit: npm provenance is now generated automatically.