### PR TITLE
ci: grant issues/PR write to fix semantic-release success step

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,8 +4,10 @@ jobs:
   cypress-run:
     runs-on: ubuntu-latest
     permissions:
-      contents: write       # semantic-release pushes tags / GitHub release
-      id-token: write       # required for npm trusted publishing (OIDC)
+      contents: write        # semantic-release pushes tags / GitHub release
+      id-token: write        # required for npm trusted publishing (OIDC)
+      issues: write          # semantic-release comments on released issues
+      pull-requests: write   # semantic-release comments on released PRs
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Context

In the run for #154 on \`main\`, trusted publishing worked end to end — **2.12.0 published to npm with provenance**, git tag and GitHub release created. But the job still exited non-zero.

## What failed

\`@semantic-release/github\`'s post-release \`success\` hook (which comments on the issues/PRs included in a release, e.g. #151) got:

\`\`\`
HttpError: Resource not accessible by integration
PATCH /repos/filiphric/cypress-plugin-api/issues/151 → 403
x-accepted-github-permissions: issues=write; pull_requests=write
\`\`\`

## Root cause

Adding an explicit \`permissions:\` block in #154 restricts \`GITHUB_TOKEN\` to *only* the listed scopes. We listed \`contents\` + \`id-token\` but omitted \`issues\` / \`pull-requests\`, so the release commenting was denied.

## Fix

Add \`issues: write\` and \`pull-requests: write\` to the job's permissions block. No effect on the (already working) OIDC publish path.