### PR TITLE
ci: bump pinned Node to 22.22.2 to fix npm@latest install

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '22.14.0'
+          node-version: '22.22.2'
       - name: Upgrade npm for trusted publishing
         run: npm install -g npm@latest   # needs >= 11.5.1
       - name: Cypress run

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,9 +14,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '22.22.2'
-      - name: Upgrade npm for trusted publishing
-        run: npm install -g npm@latest   # needs >= 11.5.1
+          node-version: '24.15.0'   # bundles npm >= 11.5.1, required for trusted publishing
       - name: Cypress run
         uses: cypress-io/github-action@v5
         with:


### PR DESCRIPTION
## Summary
- The e2e-tests/release workflow pins Node to `22.14.0`, but `npm install -g npm@latest` now requires `node ^22.22.2 || ^24.15.0 || >=26.0.0`.
- This caused the "Upgrade npm for trusted publishing" step to fail with `EBADENGINE`, aborting the job before Cypress tests or Semantic Release ran — so the last release never happened (run [30849673167](https://github.com/filiphric/cypress-plugin-api/actions/runs/30849673167)).
- Bumped pinned Node version to `22.22.2` to satisfy the engine requirement.

## Test plan
- [ ] Merge and confirm the `e2e-tests` workflow run on `main` passes through Cypress run and Semantic Release