### PR TITLE
fix: restore credential masking broken by Cypress.expose fallback regression

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -10,7 +10,7 @@ export default defineConfig({
   allowCypressEnv: true,
   e2e: {
     baseUrl: 'http://localhost:3003',
-    defaultCommandTimeout: 4000,
+    defaultCommandTimeout: 1000,
     env: {
       // Hide credentials in UI (headers, auth, body, query, cURL) so values from cy.env() stay masked
       hideCredentials: true,

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -10,7 +10,7 @@ export default defineConfig({
   allowCypressEnv: true,
   e2e: {
     baseUrl: 'http://localhost:3003',
-    defaultCommandTimeout: 1000,
+    defaultCommandTimeout: 4000,
     env: {
       // Hide credentials in UI (headers, auth, body, query, cURL) so values from cy.env() stay masked
       hideCredentials: true,

--- a/src/utils/pluginConfig.ts
+++ b/src/utils/pluginConfig.ts
@@ -3,11 +3,15 @@ import type { PluginEnvOptions } from '../types'
 const hasExpose = (): boolean =>
   typeof (Cypress as unknown as { expose?: unknown }).expose === 'function'
 
+/** Cypress.env() throws when allowCypressEnv is explicitly set to false, so it must be checked before calling Cypress.env(). */
+const canUseCypressEnv = (): boolean =>
+  (Cypress as unknown as { config: (k: string) => unknown }).config?.('allowCypressEnv') !== false
+
 /** Runtime store so values set by tests (setPluginConfig) are always visible to the plugin. Cypress.env() is not reliable for this. */
 const runtimeStore: Partial<PluginEnvOptions> = {}
 
 /**
- * Read plugin config. Checks runtime store first, then Cypress.expose() on 15.10+, then Cypress.env(), then Cypress.config('env').
+ * Read plugin config. Checks runtime store first, then Cypress.expose() on 15.10+, then Cypress.env() (unless disallowed), then Cypress.config('env').
  * So hideCredentials set in config env (or via setPluginConfig) is used to hide credentials from cy.env() in the UI.
  */
 export function getPluginConfig<K extends keyof PluginEnvOptions>(
@@ -20,8 +24,10 @@ export function getPluginConfig<K extends keyof PluginEnvOptions>(
     const exposeVal = (Cypress as unknown as { expose: (k: K) => PluginEnvOptions[K] }).expose(key)
     if (exposeVal !== undefined) return exposeVal
   }
-  const envVal = Cypress.env(key)
-  if (envVal !== undefined) return envVal
+  if (canUseCypressEnv()) {
+    const envVal = Cypress.env(key)
+    if (envVal !== undefined) return envVal
+  }
   const configEnv = (Cypress as unknown as { config: (k: string) => unknown }).config?.('env') as Partial<PluginEnvOptions> | undefined
   return configEnv?.[key]
 }
@@ -36,7 +42,7 @@ export function setPluginConfig<K extends keyof PluginEnvOptions>(
   runtimeStore[key] = value
   if (hasExpose()) {
     (Cypress as unknown as { expose: (k: K, v: PluginEnvOptions[K]) => void }).expose(key, value)
-  } else {
+  } else if (canUseCypressEnv()) {
     Cypress.env(key, value)
   }
 }

--- a/src/utils/pluginConfig.ts
+++ b/src/utils/pluginConfig.ts
@@ -7,7 +7,7 @@ const hasExpose = (): boolean =>
 const runtimeStore: Partial<PluginEnvOptions> = {}
 
 /**
- * Read plugin config. Checks runtime store first, then Cypress.expose() on 15.10+ or Cypress.env(), then Cypress.config('env').
+ * Read plugin config. Checks runtime store first, then Cypress.expose() on 15.10+, then Cypress.env(), then Cypress.config('env').
  * So hideCredentials set in config env (or via setPluginConfig) is used to hide credentials from cy.env() in the UI.
  */
 export function getPluginConfig<K extends keyof PluginEnvOptions>(
@@ -19,10 +19,9 @@ export function getPluginConfig<K extends keyof PluginEnvOptions>(
   if (hasExpose()) {
     const exposeVal = (Cypress as unknown as { expose: (k: K) => PluginEnvOptions[K] }).expose(key)
     if (exposeVal !== undefined) return exposeVal
-  } else {
-    const envVal = Cypress.env(key)
-    if (envVal !== undefined) return envVal
   }
+  const envVal = Cypress.env(key)
+  if (envVal !== undefined) return envVal
   const configEnv = (Cypress as unknown as { config: (k: string) => unknown }).config?.('env') as Partial<PluginEnvOptions> | undefined
   return configEnv?.[key]
 }


### PR DESCRIPTION
## Summary
- Root cause of the CI failures blocking the last release: `getPluginConfig()` in `src/utils/pluginConfig.ts` (changed by commit 7906251, part of PR #160 "Don't use Cypress.env on Cypress 15.10+") stopped falling back to `Cypress.env(key)` whenever `Cypress.expose` is available.
- On Cypress 15.10+, `Cypress.expose('hideCredentials')` returns `undefined` (that key was never registered in the `expose: {...}` config block), and the final fallback `Cypress.config('env')` also returns `undefined` on 15.10.0 — so `getPluginConfig('hideCredentials')` resolved to `undefined` unconditionally, silently disabling credential masking regardless of what tests (or real users) set via `Cypress.env('hideCredentials', ...)`.
- This regression was never caught because PR #160's own CI run failed earlier at an unrelated npm/Node engine-version step, before the Cypress suite ever ran.
- Fix: always fall back to `Cypress.env(key)` when `expose()` doesn't have a value, restoring the original resolution order (runtime store → expose → env → static config).
- Also reverts an earlier `defaultCommandTimeout` bump from this branch — raising it to 4000ms made no difference (confirmed the masking never rendered at any timeout), so it wasn't a timing issue.

## Test plan
- [x] Verified locally: `getPluginConfig('hideCredentials')` instrumented directly, confirmed `Cypress.expose` and `Cypress.config('env')` both return `undefined` on Cypress 15.10.0
- [x] Full local suite: 91/91 passing after the fix
- [ ] Confirm `e2e-tests` workflow passes on this PR and after merging to `main`, unblocking Semantic Release